### PR TITLE
Fixed for linux 3.2 (Debian)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -347,7 +347,7 @@ classes:
 KERNEL_INC ?=	/home/src/linux/include
 INCLUDES =	-I$(KERNEL_INC)
 
-CFLAGS =	-g -O $(INCLUDES) $(RPM_OPT_FLAGS)
+CFLAGS =	-g -fPIC -O $(INCLUDES) $(RPM_OPT_FLAGS)
 
 
 native: $(NATIVE)

--- a/native/linux.c
+++ b/native/linux.c
@@ -226,11 +226,11 @@ Java_usb_linux_DeviceImpl_controlMsg (
     } else
 	buffer = NULL;
 
-    ctrl.requesttype = requestType;
-    ctrl.request = request;
-    ctrl.value = value;
-    ctrl.index = index;
-    ctrl.length = len & 0xffff;
+    ctrl.bRequestType = requestType;
+    ctrl.bRequest = request;
+    ctrl.wValue = value;
+    ctrl.wIndex = index;
+    ctrl.wLength = len & 0xffff;
     ctrl.timeout = TIMEOUT;	// USB should t/o after 5 seconds.
     ctrl.data = buffer + off;
     if ((retval = ioctl (fd, USBDEVFS_CONTROL, &ctrl)) < 0)


### PR DESCRIPTION
Hi Dan, had to tweak jusb a bit to get it to build on my system (Debian Wheezy, 3.2.0). Seems like the naming of usbdevfs_ctrltransfer changed, and also gcc wanted -fPIC to build the native library. Pull request is mostly as an FYI / heads-up.
