### PR TITLE
Fix control read error by skipping deviceClass==0xFF

### DIFF
--- a/native/macosx.c
+++ b/native/macosx.c
@@ -515,8 +515,10 @@ void DeviceAdded(void *refCon, io_iterator_t iterator) {
             continue;
         }
         kr = (*privateDataRef->device)->GetDeviceClass(privateDataRef->device, &deviceClass);
-        if ( KERN_SUCCESS != kr || deviceClass == 0x09) {
+        if ( KERN_SUCCESS != kr || deviceClass == 0x09 || deviceClass == 0xff) {
             //we don't want jusb talking to Hubs (deviceClass 0x09) 'cause that crashes the bus?
+            //we don't want jusb talking to (deviceClass 0xff) as this throws a control read error in IOkit on OSX
+            //usb.macosx.USBException: control read error --  [0x1ffffd13]  [0x1ffffd13]
             releasePrivateData(privateDataRef);
             continue;
         }


### PR DESCRIPTION
```
usb.macosx.USBException: control read error --  [0x1ffffd13]
[0x1ffffd13]
    at usb.macosx.DeviceImpl.readControl(DeviceImpl.java:458)
    at usb.core.Device.control(Device.java:217)
    at usb.core.ControlMessage.getDescriptor(ControlMessage.java:354)
    at
usb.core.ControlMessage.getStandardDescriptor(ControlMessage.java:286)
    at usb.macosx.DeviceImpl.<init>(DeviceImpl.java:112)
    at usb.macosx.USB.<init>(USB.java:82)
    at usb.macosx.MacOSX$HostImpl.mkBus(MacOSX.java:239)
    at usb.macosx.MacOSX.newDeviceAvailable(MacOSX.java:263)
    at usb.macosx.MacOSX.scanForDevices(Native Method)
    at usb.macosx.MacOSX$HostImpl.run(MacOSX.java:201)
    at java.lang.Thread.run(Thread.java:745)
```
